### PR TITLE
Breaking: Make `react` optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^9.1.0",
+    "@types/react": "^17.0.40",
     "@types/sinon": "^10.0.11",
     "@typescript-eslint/eslint-plugin": "^4.0.1",
     "eslint": "^7.12.1",
@@ -33,6 +34,11 @@
   },
   "peerDependencies": {
     "react": "^17.0.2"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
   },
   "type": "module",
   "exports": "./dist/index.js",


### PR DESCRIPTION
Fixes #3 